### PR TITLE
Move content to src/content

### DIFF
--- a/web/scripts/notes-from-issue.ts
+++ b/web/scripts/notes-from-issue.ts
@@ -26,7 +26,7 @@ async function fetchIssues() {
             }
 
             if (hasNoteLabel) {
-                const filePath = path.join(__dirname, '../src/pages/note', `${issue.number}.md`);
+                const filePath = path.join(__dirname, '../content/note', `${issue.number}.md`);
                 const content = `---
 layout: ../../layouts/blog-post.astro
 title: "${issue.title}"

--- a/web/src/content/blog/2023/develop-in-codespaces-and-devcontainer.md
+++ b/web/src/content/blog/2023/develop-in-codespaces-and-devcontainer.md
@@ -1,0 +1,142 @@
+---
+layout: ../../../layouts/blog-post.astro
+title: 個人開発を Codespaces と DevContainer へ移行
+emoji: ⚙️
+date: 2023-05-06
+tags:
+  - devcontainer
+  - codespaces
+  - vscode
+---
+
+[Codespaces](https://github.com/features/codespaces) が利用できるようになってから、ちょっとした開発は Codespaces を行っていたのですが、最近は個人の開発はすべて Codespaces で十分だと思えてきたので完全に移行しようと思いました。
+ただ、基本的には無料枠でやっているので[^1]、ある程度腰を据えて開発していると枠が足りなくなるのと、Chrome 拡張の開発は毎回成果物のダウンロードが必要だったりで不便なところは少しあるので、それを埋めるために一部で [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers) を使って、手元のマシン内で開発可能な環境を整えることにしました。
+
+[^1]: 追加することに抵抗があるわけではないので、理由がなければ Codespaces を継続してます。
+
+これは、その準備をしたときの作業ログと未来の自分に向けたメモです。ある程度 Codespaces を触ったことがあるという前提で書かれています。
+
+## 開発用コンテナと Dockfile について
+
+Codespaces と Dev Container で使用するコンテナに関する設定を区別する必要なく、同じものが使えます。
+Docker Desktop に相当するものがインストールされていれば、VSCode に Dev Containers のプラグインを入れればそのまま利用可能です。
+
+- https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers
+
+ローカルで開発するときはコードを適当な場所に clone して「Open in container」から開きます。コマンドパレットからも開き直せます、その場合は Reopen ~ になります。
+
+### Clone Repository in Container
+
+コードの clone をコンテナの中で行うという方法もあるようです。これを利用すると Codespace とほとんど同じ感覚で使えるようです。
+
+- [【vscode】devcontainerのClone in container volumeがよいという話](https://weseek.co.jp/tech/4112/)
+- [Create a development container using Visual Studio Code Remote Development](https://code.visualstudio.com/docs/devcontainers/create-dev-container#_add-an-open-in-dev-container-badge)
+
+ただ、何回試してみたのですが、shallow clone になってしまってだるいのと、成果物がコンテナ内に入ってしまうので取り出すのがめんどくさい、という理由があって使っていません。
+
+### OrbStack
+
+個人の MBA では Docker Desktop の代わりに [OrbStack](https://orbstack.dev/) を試しています。
+
+- [OrbStack · Fast, light, simple Docker & Linux on macOS](https://orbstack.dev/)
+- [OrbStack使ってみた](https://zenn.dev/daifukuninja/articles/6285b5491a05e5)
+
+いまのところ特に問題なく Docker Desktop の代わりとして使えています。
+
+## Dotfiles について
+
+ここ数年は fish を使っていたのですが、devcontainers のものにはデフォルトでは入っていないので、これを機に zsh に戻してみることにしました。
+これまで Codespaces を使うときは不便を感じつつも特にカスタマイズをしていなかったので、今回ちゃんと設定を整えてみることにしました。
+
+- [yaakaito/env](https://github.com/yaakaito/env)
+
+開発に使う devcontainer をある程度テンプレ化しておきたかったので[^2] dotfiles ではなくて env という名前にしてみました。
+
+[^2]: テンプレートリポジトリはリポジトリが増えるし同じようなことをそれぞれに更新かけたりがだるいので。
+
+Codepsaces の場合は、GitHub の設定から dotfiles のリポジトリを指定することで、Codespaces が起動するときに dotfiles の内容がコンテナにコピーされ、setup.sh が実行されます。
+
+- [アカウントの GitHub Codespaces をパーソナライズする - GitHub Docs](https://docs.github.com/ja/codespaces/customizing-your-codespace/personalizing-github-codespaces-for-your-account#turning-on-settings-sync-in-a-codespace)
+
+Dev Container の場合は、VSCode の設定から GitHub にある dotfiles のリポジトリを指定ことができます。これをすると Codespaces と同等の挙動になります。
+
+```json
+{
+  "dotfiles.repository": "yaakaito/env",
+  "dotfiles.targetPath": "~/.env",
+}
+```
+
+### zsh のカスタマイズ
+
+とはいえ欲しい物が fish っぽく動いてほしいくらいだったので、次の記事を参考に [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) と [zsh-syntaxhighlight](https://github.com/zsh-users/zsh-syntax-highlighting/) を入れて、fish ライクに、peco で ctrl-r に履歴検索、ctrl-s でディレクトリ移動をバインドしています。
+
+- [Setup guide for ZSH in GitHub codespaces - DEV Community](https://dev.to/krish_agarwal/setup-guide-for-zsh-in-github-codespaces-5152)
+- [ghqでリポジトリ管理を簡単にする](https://zenn.dev/oreo2990/articles/13c80cf34a95af)
+- [pecoを使ったらターミナルの操作が劇的に効率化できた話 - Qiita](https://qiita.com/keisukee/items/9b815e56a173a281f42f)
+
+他には pnpm などの補完がほしいところですが、これは使うコンテナによって必要なものが違うので、Dockerfile の方で有効にしています。例えば pnpm の場合は以下のような感じです。
+
+- [Command line tab-completion | pnpm](https://pnpm.io/completion)
+
+```dockerfile
+USER vscode
+RUN corepack prepare pnpm@8.2.0 --activate
+RUN pnpm install-completion zsh
+```
+
+## Copilot や VSCode の拡張機能について
+
+これまではあまり意識せずに Copilot を Codespaces にインストールして使っていたのですが、これを設定している途中で、コンテナ内で開発する際に Copilot が有効にならないことがあることに気づきました。これは Codespaces に限らず、Dev Container でも同じでした。他にもいくつかの拡張機能が動作しないことがあったのですが、これは container.json に設定を追加することで解決しました。
+
+- [GitHub Codespaces での GitHub Copilot の使用 - GitHub Docs](https://docs.github.com/ja/codespaces/codespaces-reference/using-github-copilot-in-github-codespaces)
+- [Development Container Specification](https://containers.dev/implementors/spec/#implementation-specific-steps)
+
+`customizations.vscode.extensions` フィールドを設定することで、コンテナで有効にする VSCode の拡張機能を指定することができるようです。これを使って Copilot や必要な拡張を有効にすることにしました。
+
+```json
+{
+    "build": { "dockerfile": "Dockerfile" },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "github.copilot",
+                "astro-build.astro-vscode" // 例えば Astro を使う場合
+            ]
+        }
+    }
+}
+```
+
+## 今回やらなかったがやりたいこと
+
+Codespaces や Dev Container を使った開発では、シェルの history が残らないため、永続化したい場合は別途手段を用意する必要があるようです。
+
+- [GitHub Codespace で Terminal の入力履歴を永続化し Codepace 間で共有してみる](https://zenn.dev/hankei6km/articles/persist-command-history-in-github-codesapces)
+
+history が永続化できるとそもそも不要かもしれませんが、cheat を使ったスニペットを env リポジトリに含めて置けると便利そうです。
+
+- [cheat/cheat: cheat allows you to create and view interactive cheatsheets on the command-line. It was designed to help remind \*nix system administrators of options for commands that they use frequently, but not frequently enough to remember.](https://github.com/cheat/cheat)
+
+## 2023-05-14 追記
+
+しばらく触っていなかったリポジトリを同じ要領で触ってみたら、DevContainer 側で VSCode の Extention のインストールが全く進まずに困っていたのですが、Dockerfile が原因でした。
+かなり前に公式を参考に devcontainer.json と Dockerfile を作った際に、その Dockerfile はこんな感じに定義されていて、
+
+```
+ARG VARIANT=bullseye
+FROM --platform=linux/amd64 mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+```
+
+`linux/amd64` を指定していると M2 Mac 上のコンテナに Extention がインストールできなくなるようでした。platform は指定しなければ自動で選択してくれるので、
+
+```
+ARG VARIANT=bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+```
+
+に変更して無事動くようになりました。当時参考にしたドキュメントが見つからなかったんですが、現在のものは platform を指定していないので問題なさそうです。
+
+- https://docs.github.com/ja/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers
+
+そもそもトレンドとしては Dockerfile は使わず、devcontainer.json だけで完結するのがよいようにも思います。

--- a/web/src/content/blog/2025/popover-dialog.md
+++ b/web/src/content/blog/2025/popover-dialog.md
@@ -1,0 +1,155 @@
+---
+layout: ../../../layouts/blog-post.astro
+title: Popover API と Dialog に関する備忘録
+emoji: 🎈
+date: 2025-01-23
+tags:
+  - Web
+  - HTML
+  - CSS
+  - JavaScript
+---
+
+2024 年の Baseline に追加された機能として Popover API があり、またそれに関連するものとして Dialog がすでに実装されている。
+この 2 つは目的は違うが技術的には似たものになっているので、それぞれの特徴などをまとめる。
+
+動作サンプル: https://yaakaito.github.io/code-sandbox/popover-and-dialog/
+
+## 前提知識
+
+### Top Layer
+
+- [Top layer (最上位レイヤー) - MDN Web Docs 用語集: ウェブ関連用語の定義 | MDN](https://developer.mozilla.org/ja/docs/Glossary/Top_layer)
+
+従来のz-indexとは異なる、ブラウザネイティブの最前面レイヤー。PopoverとDialogのモーダルモードは、このTop layerを利用して要素を描画する。入れ子も可能だが、Light Dismiss（要素外クリックでの閉じる）の挙動には注意が必要となる。
+
+
+## 利用用途による違い
+
+- Popover
+    - カレンダーのようなフォームでの特殊な入力 UI
+    - 通知、トースト
+    - チュートリアル UI
+- モーダル Dialog
+    - 利用規約への同意のようなそれ以外を操作できないような UI
+    - 削除のような重要な確認操作
+- 非モーダル Dialog
+    - Cookie の利用許可のような、ユーザーに同意を求めるが、コンテンツは操作できる UI
+    - プライベート URL で共有を行うようなコンテンツでの、共有に関する警告の UI
+
+## Popover
+
+[ポップオーバー API - Web API | MDN](https://developer.mozilla.org/ja/docs/Web/API/Popover_API)
+
+Popover は属性で、任意の要素を Top layer へ配置することができる。ダイアログやモーダルではないので、アクセシビリティといった視点で意味は持たず、基本的には背景の要素に操作が貫通する。
+
+```html
+<button popovertarget="mypopover">toggle popover</button>
+<div id="mypopover" popover="auto|manual|hint">Popover content</div>
+```
+
+popover 属性には現状 3 つの値を設定することができ、これによって Light Dismiss や表示方法をコントロールする。
+
+- `auto`: デフォルト値で、Light Dismiss が有効になる
+- `manual`: Light Dismiss が無効になり、閉じるための動作を実装する必要がある
+- `hint`: 「hint」は Chrome 133 から導入された（される予定の）機能で、この値が設定されている Popover は同時に1つしか表示されない
+
+JS からもコントロール可能だが、必ず属性に `popover` が付与されている必要がある。
+
+```jsx
+popover.showPopover()
+popover.hidePopover()
+```
+
+## Dialog
+
+[&lt;dialog&gt;: ダイアログ要素 - HTML: ハイパーテキストマークアップ言語 | MDN](https://developer.mozilla.org/ja/docs/Web/HTML/Element/dialog)
+
+Dialog はユーザーに操作を求めるための役割（`role=dialog`）を持つ。モーダル/非モーダルの2つのモードがあり、特にモーダルモードではTop layerへの表示と背景操作のロックを行う。JS での制御が想定されていて、`showModal()` を利用することでモーダルダイアログが、`show()` を利用することで非モーダルダイアログが表示される。
+
+```html
+<dialog id="dialog">
+    <h1>Dialog</h1>
+    <p>This is a dialog.</p>
+    <button>Close</button>
+</dialog>
+<script>
+    const dialog = document.getElementById('dialog');
+    dialog.showModal();
+</script>
+```
+
+モーダルの場合、次の機能がブラウザネイティブで提供される。これによって、これまでの実装よりもアクセシビリティや UX の向上が期待できる。
+
+- inert による背景 UI のロック
+    - [inert - HTML: ハイパーテキストマークアップ言語 | MDN](https://developer.mozilla.org/ja/docs/Web/HTML/Global_attributes/inert)
+    - `.showModal()` で表示された Dialog は、Top Layer でない要素が inert となる
+- :backdrop による背景の表示
+    - [::backdrop - CSS: カスケーディングスタイルシート | MDN](https://developer.mozilla.org/ja/docs/Web/CSS/::backdrop)
+    - Top layer と背景コンテンツの間に表示される領域で、モーダルダイアログではデフォルトで半透明の背景が表示されており、ユーザーの操作を受け付けないことを表現している
+- ESC での閉じるのサポート
+    - Light Dismiss ではない
+- フォーカスの管理
+    - モーダルダイアログが表示された際に、その中の要素にフォーカスが移動する
+    - ダイアログが閉じられた際に、直前のフォーカス位置に戻る
+
+
+## Anchor Positioning
+
+[CSS アンカー位置指定の使用 - CSS: カスケーディングスタイルシート | MDN](https://developer.mozilla.org/ja/docs/Web/CSS/CSS_anchor_positioning/Using)
+
+特定要素を基準とした配置をサポート。Top layer要素でも有効で、Popoverと組み合わせて使用できる。
+
+```html
+<style>
+   #anchorPopoverTrigger {
+        anchor-name: --anchor-target;
+   }
+   #anchorPopover  {
+        position-anchor: --anchor-target;
+        position-area: bottom span-right;
+        position-try-fallbacks: flip-inline, flip-inline flip-block;
+        margin: 0;
+        width: 300px;
+   }
+</style>
+<button id="anchorPopoverTrigger" popovertarget="anchorPopoverLeft">toggle anchor popover</button>
+<div id="anchorPopover" popover>
+    Anchor Popover Left
+</div>
+
+```
+
+position-area による配置指定が基本となりそうだが、top や left などを使用した直接的な位置指定も可能。
+
+- [https://developer.mozilla.org/ja/docs/Web/CSS/CSS_anchor_positioning/Using#position-area_の設定](https://developer.mozilla.org/ja/docs/Web/CSS/CSS_anchor_positioning/Using#position-area_%E3%81%AE%E8%A8%AD%E5%AE%9A)
+
+fallback を設定することができ、画面に収まらない場合の挙動を調整することが出来る。
+
+- https://developer.mozilla.org/en-US/docs/Web/CSS/position-try-fallbacks
+
+### Close Watcher
+
+[CloseWatcher - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/CloseWatcher)
+
+ユーザーが閉じようとした動作を検知できる API で、具体的には ESC や戻るを押したタイミングが検知できる。`popover=manual` や非モーダルダイアログには ESC での閉じる機能がないので、対応する必要が出てきたときに有効。
+
+```jsx
+let closeWatcher = null
+popoverTrigger.addEventListener('click', () => {
+    if (closeWatcher) {
+        closeWatcher.destroy()
+    }
+    closeWatcher = new CloseWatcher()
+    closeWatcher.onclose = () => {
+        popover.hidePopover()
+    }
+    popover.showPopover()
+})
+```
+
+## Refs
+
+- [#Tags | blog.jxck.io](https://blog.jxck.io/tags/#popover)
+- [CSS Anchor Positioning 仕様の紹介](https://zenn.dev/d_kawaguchi/articles/css-anchor-positioning-294aa71a7f77fc)
+- [UI を閉じる動作を処理する CloseWatcher API](https://azukiazusa.dev/blog/close-watcher-api/)

--- a/web/src/content/note/1.md
+++ b/web/src/content/note/1.md
@@ -1,0 +1,26 @@
+---
+layout: ../../layouts/blog-post.astro
+title: "node 22 の標準 glob を利用する"
+emoji: 🖊
+date: 2024-06-02T20:07:55Z
+tags:
+    - note
+---
+
+Node 22 では実験的な機能として `glob` と `globSync` が導入されました。
+
+- https://nodejs.org/en/blog/announcements/v22-release-announce#glob-and-globsync
+
+これまで glob パッケージを利用していた場合、次のように置き換えることが出来ます。
+
+- https://www.npmjs.com/package/glob
+
+
+```diff
+- const glob = require('glob');
++ const { glob, globSync} = require('fs');
+
+  glob('*', (error, matches) => {});
+- const matches = glob.sync('*');
++ const matches = globSync('*');
+```

--- a/web/src/content/note/2.md
+++ b/web/src/content/note/2.md
@@ -1,0 +1,95 @@
+---
+layout: ../../layouts/blog-post.astro
+title: "React 19 Actions"
+emoji: 🖊
+date: 2024-06-02T20:13:05Z
+tags:
+    - note
+---
+
+React 19 では、データ更新とそれに伴う一連の流れをうまく扱う方法として Actions が導入されるようです。
+例えば、これまでフォームの送信中の状態を次のように扱うことがありましたが、これが React の機能として標準化されます。
+
+```tsx
+const [isPending, setIsPending] = useState(false);
+const submit = () => {
+  setIsPending(true);
+  await foo();
+  setIsPending(false);
+}
+return (
+      <form>
+        <button click={submit} disable={isPending}>foo</button>
+      </form>
+    )
+```
+
+新しく導入される Actions の一つである `useActionState` を利用して書くと次のように書けます。
+
+```tsx
+const [error, submitAction, isPending] = useActionState(
+  async () => {
+    const error = await foo();
+    if (error) { return error; }
+    return null;
+  }
+)
+return (
+      <form action={submitAction}>
+        <button type="submit" disable={isPending}>foo</button>
+      </form>
+    )
+```
+
+Hook に渡した関数は実質的に `submitAction` の内容になっていて、`isPending` はその関数の実行状態に合わせて値が変化します。
+これによって最初のコードと同等に `isPending` を使って UI の状態を変更できる、ということのようです。
+
+### useFormStatus
+
+これに組み合わせて使えるものとして `useFormStatus` という親の `form` の実行状態を取得することが出来る Hook もあります、これは react-dom から提供されるものです。
+例えばボタンコンポーネントを作るときにその状態を外から Props として渡すことがあると思いますが、 Actions を使った form の中ではこれを簡略化することが出来ます。
+
+```tsx
+function FooSubmit() {
+  const { pending } = useFormStatus();
+  <button type="submit" disable={pending}>foo</button>
+}
+
+function FooForm() {
+  const [error, submitAction, isPending] = useActionState(
+    async () => {
+      const error = await foo();
+      if (error) { return error; }
+      return null;
+    }
+  )
+  return (
+        <form action={submitAction}>
+          <FooSubmit />
+        </form>
+      )
+}
+```
+
+これが `useActionState` の例と同じ動作になるようです。
+
+### useOptimistic
+
+Actions が失敗したときに巻き戻される `useState` のようなものです。次にコードで `await foo()` が失敗すると、 `value` が `currentValue` に戻ります。
+
+```tsx
+const [value, setValue] = useOptimistic('currentValue')
+const [error, submitAction, isPending] = useActionState(
+  async () => {
+    setValue('newValue')
+    const error = await foo();
+    if (error) { return error; }
+    return null;
+  }
+)>
+```
+
+ユーザー名を変更したいが、重複チェックに時間がかかるような場合に、結果の予定を先に UI に反映しておくような場合にその実装が標準化できるようです。
+
+- https://react.dev/blog/2024/04/25/react-19
+- https://react.dev/reference/react-dom/hooks/useFormStatus

--- a/web/src/content/note/3.md
+++ b/web/src/content/note/3.md
@@ -1,0 +1,43 @@
+---
+layout: ../../layouts/blog-post.astro
+title: "@mozilla/readability を使った HTML からの本文抽出"
+emoji: 🖊
+date: 2024-06-02T20:13:24Z
+tags:
+    - note
+---
+
+@mozilla/readability を使うと簡単に本文を抽出することができます。これは Firefox のリーダービューで使われているもののようです。
+
+- https://github.com/mozilla/readability
+- https://support.mozilla.org/ja/kb/firefox-reader-view-clutter-free-web-pages
+
+今回はこの結果を Claude3 に投げたかったので、DOMPurify を組み合わせて最小限文章がわかりそうな DOM として取り出しています。
+
+- https://github.com/cure53/DOMPurify
+
+```ts
+import { Readability } from '@mozilla/readability';
+import { JSDOM } from 'jsdom';
+import createDOMPurify from 'dompurify';
+
+export const getReadability = async (url: string) => {
+    const content = await fetch(url).then(res => res.text());
+    const reader = new Readability(new JSDOM(content, {
+        url
+    }).window.document);
+    const readability = (reader.parse() ?? { content: '' });
+    return createDOMPurify(new JSDOM('').window).sanitize(readability.content, {
+        ALLOWED_TAGS: [
+            'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+            'blockquote', 'code', 'pre',
+            'p', 'br', 'hr',
+            'a', 'img', 'table', 'thead', 'tbody', 'tr', 'th', 'td',
+            'ul', 'ol', 'li',
+            'dl', 'dt', 'dd',
+        ],
+        ALLOWED_ATTR: ['href', 'src', 'title', 'alt'],
+    });
+}
+
+```

--- a/web/src/content/note/4.md
+++ b/web/src/content/note/4.md
@@ -1,0 +1,28 @@
+---
+layout: ../../layouts/blog-post.astro
+title: "Node 組み込みテストランナーと swc で TypeScript をテストする"
+emoji: 🖊
+date: 2024-06-02T20:13:39Z
+tags:
+    - note
+---
+
+Node 18 から実験的に導入された組み込みのテストランナーがありますが、これが 21 で対象を glob 指定できるようになりました。
+
+- https://nodejs.org/en/blog/announcements/v18-release-announce#test-runner-module-experimental
+- https://nodejs.org/en/blog/announcements/v21-release-announce#support-for-globs-in-the-nodejs-test-runner
+
+swc-node と組み合わせると、それなりに使えそうなテストランナーになりそうです。
+
+- https://github.com/swc-project/swc-node
+
+これらを用意した状態で次のコマンドにすると、 TS をトランスパイルしつつ watch モードで動くテストランナーが作れます。
+
+```sh
+$ node --import @swc-node/register/esm-register --watch --test 'src/**/*.test.ts'
+```
+
+> [!NOTE]
+> webpack などのバンドラーを使って ESM で記述している場合、Node の ESM と共存できるようにする必要があります。
+> 自分は import を `*.js` で行うようにし、 `extentionAlias` で `import xxx from './xxx.js'` を `.ts` としても解決できるようにしました。
+> https://webpack.js.org/configuration/resolve/#resolveextensionalias

--- a/web/src/content/note/5.md
+++ b/web/src/content/note/5.md
@@ -1,0 +1,16 @@
+---
+layout: ../../layouts/blog-post.astro
+title: "CLI から VSCode の拡張を入れる"
+emoji: 🖊
+date: 2024-06-02T20:13:54Z
+tags:
+    - note
+---
+
+`--install-extension` というコマンドがあり、これを使うと CLI から拡張機能をインストールできる。
+プロジェクトに直接関係しないけど devcontainer に入っていてほしい、みたいなものに個人の設定で使うと便利。
+
+```
+code --install-extension mhutchie.git-graph
+code --install-extension eamodio.gitlens
+```

--- a/web/src/content/note/6.md
+++ b/web/src/content/note/6.md
@@ -1,0 +1,35 @@
+---
+layout: ../../layouts/blog-post.astro
+title: ":has() でリストが空のときにセクションごと消す"
+emoji: 🖊
+date: 2024-06-02T20:14:07Z
+tags:
+    - note
+---
+
+`:has()` が 2023 年末にすべてのブラウザでサポートされて、現実的に利用できるようになった。
+
+- [:has() - CSS: カスケーディングスタイルシート | MDN](https://developer.mozilla.org/ja/docs/Web/CSS/:has)
+- [朗報！ CSSの:has()疑似クラスがすべてのブラウザにサポートされました、:has()疑似クラスの便利な使い方のまとめ | コリス](https://coliss.com/articles/build-websites/operation/css/css-has-pseudo-class.html)
+
+「渡したセレクターにマッチする子要素を持つ親要素であるか」を判定できるので、例えばリストが空のときにセクションごと消すことができる。
+
+```html
+<style>
+section:has(ul:empty) {
+  display: none;
+}
+</style>
+<section class="section">
+  <h1>section1</h1>
+  <ul>
+    <li>item1</li>
+    <li>item2</li>
+  </ul>
+</section>
+<section class="section">
+  <h1>section2</h1>
+  <ul>
+  </ul>
+</section>
+```

--- a/web/src/pages/blog/index.astro
+++ b/web/src/pages/blog/index.astro
@@ -3,7 +3,7 @@ import GlobalLayout from "../../layouts/global-layout.astro";
 import type { MarkdownInstance } from "astro";
 
 // ディレクトリ内の全ての .md ファイルを取得
-const blogPosts = await Astro.glob<{ title: string; date: string; emoji: string }>('./**/*.md');
+const blogPosts = await Astro.glob<{ title: string; date: string; emoji: string }>('../../content/blog/**/*.md');
 
 // ファイルを読み込む非同期関数
 function loadPosts(posts: MarkdownInstance<{ title: string; date: string; emoji: string }>[]) {

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -5,8 +5,8 @@ import icon from "../../../icon/icon-512.png";
 import type { MarkdownInstance } from "astro";
 
 // ディレクトリ内の全ての .md ファイルを取得
-const blogPosts = await Astro.glob<{ title: string; date: string; emoji: string }>('./blog/**/*.md');
-const notePosts = await Astro.glob<{ title: string; date: string; emoji: string }>('./note/**/*.md');
+const blogPosts = await Astro.glob<{ title: string; date: string; emoji: string }>('../content/blog/**/*.md');
+const notePosts = await Astro.glob<{ title: string; date: string; emoji: string }>('../content/note/**/*.md');
 
 // ファイルを読み込む非同期関数
 function loadPosts(posts: MarkdownInstance<{ title: string; date: string; emoji: string }>[]) {

--- a/web/src/pages/note/index.astro
+++ b/web/src/pages/note/index.astro
@@ -3,7 +3,7 @@ import GlobalLayout from "../../layouts/global-layout.astro";
 import type { MarkdownInstance } from "astro";
 
 // ディレクトリ内の全ての .md ファイルを取得
-const notePosts = await Astro.glob<{ title: string; date: string; emoji: string }>('./**/*.md');
+const notePosts = await Astro.glob<{ title: string; date: string; emoji: string }>('../../content/note/**/*.md');
 
 // ファイルを読み込む非同期関数
 function loadPosts(posts: MarkdownInstance<{ title: string; date: string; emoji: string }>[]) {

--- a/web/src/pages/rss.xml.js
+++ b/web/src/pages/rss.xml.js
@@ -3,8 +3,8 @@ import sanitizeHtml from 'sanitize-html';
 
 export async function GET(context) {
     // ディレクトリ内の全ての .md ファイルを取得
-    const blogPosts = Object.values(import.meta.glob('./blog/**/*.md', { eager: true }));
-    const notePosts = Object.values(import.meta.glob('./note/**/*.md', { eager: true }));
+    const blogPosts = Object.values(import.meta.glob('../content/blog/**/*.md', { eager: true }));
+    const notePosts = Object.values(import.meta.glob('../content/note/**/*.md', { eager: true }));
 
     const items = [];
     for (const post of [...blogPosts, ...notePosts]) {


### PR DESCRIPTION
Fixes #21

Move content files to `src/content` in accordance with Astro's content collection guidelines.

* **Blog Posts**: Move blog post files from `web/src/pages/blog` to `web/src/content/blog`.
* **Notes**: Move note files from `web/src/pages/note` to `web/src/content/note`.
* **Index Files**: Update `web/src/pages/index.astro`, `web/src/pages/blog/index.astro`, and `web/src/pages/note/index.astro` to reference the new locations of blog posts and notes.
* **RSS Feed**: Update `web/src/pages/rss.xml.js` to reference the new locations of blog posts and notes.
* **Script**: Update `web/scripts/notes-from-issue.ts` to save issues as Markdown files in the new location `src/content/note`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yaakaito/yaakaito/pull/22?shareId=6922d492-b729-45dc-8385-a4d962f3ca7e).