### PR TITLE
Migrate to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -48,9 +48,9 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
-          # Upload entire repository
+          name: pages-artifact
           path: './web/dist'
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
Fixes #29

Update the deploy workflow to use `actions/upload-artifact@v4`.

* Replace `actions/upload-pages-artifact@v1` with `actions/upload-artifact@v4` in `.github/workflows/static.yml`
* Update the `with` section to include `name: pages-artifact` and `path: './web/dist'`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yaakaito/yaakaito/pull/30?shareId=e6b25bf6-7913-4602-984e-aaa8882f38d7).