### PR TITLE
Fix artifact v4 deployment issue

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -51,7 +51,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: pages-artifact
-          path: './web/dist'
+          path: 'web/dist'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1
+        with:
+          artifact_name: pages-artifact


### PR DESCRIPTION
Fixes #31

Update GitHub Actions workflow to fix deployment issue with artifact v4.

* **Upload Artifact Step:**
  - Change the `path` parameter in the `actions/upload-artifact@v4` step to `web/dist`.

* **Deploy to GitHub Pages Step:**
  - Add the `artifact_name` parameter with the value `pages-artifact` to the `actions/deploy-pages@v1` step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yaakaito/yaakaito/pull/33?shareId=66c08ddf-b30e-4a91-950c-a41944829315).