### PR TITLE
Add OGP block elements to replace URLs in specified formats

### DIFF
--- a/web/src/components/OGPBlock.astro
+++ b/web/src/components/OGPBlock.astro
@@ -1,0 +1,66 @@
+---
+import { fetchOGPData } from '../utils/fetchOGPData';
+
+interface Props {
+  url: string;
+}
+
+const { url } = Astro.props;
+const ogpData = await fetchOGPData(url);
+---
+
+{ogpData ? (
+  <div class="ogp-block">
+    <img src={ogpData.image} alt={ogpData.title} class="ogp-image" />
+    <div class="ogp-content">
+      <h3 class="ogp-title">{ogpData.title}</h3>
+      <p class="ogp-description">{ogpData.description.slice(0, 50)}...</p>
+    </div>
+  </div>
+) : (
+  <a href={url}>{url}</a>
+)}
+
+<style>
+  .ogp-block {
+    display: flex;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    overflow: hidden;
+    margin: 16px 0;
+    text-decoration: none;
+    color: inherit;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    transition: transform 0.2s, box-shadow 0.2s;
+  }
+
+  .ogp-block:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+  }
+
+  .ogp-image {
+    width: 120px;
+    height: 120px;
+    object-fit: cover;
+  }
+
+  .ogp-content {
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .ogp-title {
+    font-size: 1.2em;
+    margin: 0 0 8px;
+    font-weight: bold;
+    color: #333;
+  }
+
+  .ogp-description {
+    font-size: 0.9em;
+    color: #666;
+  }
+</style>

--- a/web/src/layouts/blog-post.astro
+++ b/web/src/layouts/blog-post.astro
@@ -1,5 +1,6 @@
 ---
 import GlobalLayout from "../layouts/global-layout.astro";
+import OGPBlock from "../components/OGPBlock.astro";
 const { frontmatter } = Astro.props;
 const dateString = new Date(frontmatter.date).toLocaleDateString("en-US", {
     year: "numeric",
@@ -177,7 +178,9 @@ const dateString = new Date(frontmatter.date).toLocaleDateString("en-US", {
             <time datetime={frontmatter.date}>{dateString}</time>
             <h1 class="title">{frontmatter.title}</h1>
         </hgroup>
-        <div class="markdown"><slot /></div>
+        <div class="markdown">
+            <slot />
+        </div>
     </div>
     <script>
         document.addEventListener("DOMContentLoaded", function(event) {
@@ -191,6 +194,15 @@ const dateString = new Date(frontmatter.date).toLocaleDateString("en-US", {
                 // norefferer
                 link.setAttribute("rel", "noopener noreferrer");
             });
+
+            // Replace URLs with OGPBlock components
+            const markdownContent = document.querySelector(".markdown");
+            if (markdownContent) {
+                const urlRegex = /https?:\/\/[^\s]+/g;
+                markdownContent.innerHTML = markdownContent.innerHTML.replace(urlRegex, (url) => {
+                    return `<OGPBlock url="${url}" />`;
+                });
+            }
         });
     </script>
 </GlobalLayout>

--- a/web/src/pages/blog/index.astro
+++ b/web/src/pages/blog/index.astro
@@ -1,5 +1,6 @@
 ---
 import GlobalLayout from "../../layouts/global-layout.astro";
+import OGPBlock from "../../components/OGPBlock.astro";
 import type { MarkdownInstance } from "astro";
 
 // ディレクトリ内の全ての .md ファイルを取得
@@ -64,4 +65,16 @@ const blogs = loadPosts(blogPosts);
             ))}
         </div>
     </div>
+    <script>
+        document.addEventListener("DOMContentLoaded", function(event) {
+            // Replace URLs with OGPBlock components
+            const markdownContent = document.querySelector(".markdown");
+            if (markdownContent) {
+                const urlRegex = /https?:\/\/[^\s]+/g;
+                markdownContent.innerHTML = markdownContent.innerHTML.replace(urlRegex, (url) => {
+                    return `<OGPBlock url="${url}" />`;
+                });
+            }
+        });
+    </script>
 </GlobalLayout>

--- a/web/src/pages/note/index.astro
+++ b/web/src/pages/note/index.astro
@@ -1,5 +1,6 @@
 ---
 import GlobalLayout from "../../layouts/global-layout.astro";
+import OGPBlock from "../../components/OGPBlock.astro";
 import type { MarkdownInstance } from "astro";
 
 // ディレクトリ内の全ての .md ファイルを取得
@@ -64,4 +65,16 @@ const notes = loadPosts(notePosts);
             ))}
         </div>
     </div>
+    <script>
+        document.addEventListener("DOMContentLoaded", function(event) {
+            // Replace URLs with OGPBlock components
+            const markdownContent = document.querySelector(".markdown");
+            if (markdownContent) {
+                const urlRegex = /https?:\/\/[^\s]+/g;
+                markdownContent.innerHTML = markdownContent.innerHTML.replace(urlRegex, (url) => {
+                    return `<OGPBlock url="${url}" />`;
+                });
+            }
+        });
+    </script>
 </GlobalLayout>

--- a/web/src/utils/fetchOGPData.ts
+++ b/web/src/utils/fetchOGPData.ts
@@ -1,0 +1,31 @@
+import fetch from 'node-fetch';
+
+interface OGPData {
+  title: string;
+  description: string;
+  image: string;
+}
+
+export async function fetchOGPData(url: string): Promise<OGPData | null> {
+  try {
+    const response = await fetch(url);
+    const html = await response.text();
+
+    const titleMatch = html.match(/<meta property="og:title" content="(.*?)"/);
+    const descriptionMatch = html.match(/<meta property="og:description" content="(.*?)"/);
+    const imageMatch = html.match(/<meta property="og:image" content="(.*?)"/);
+
+    if (titleMatch && descriptionMatch && imageMatch) {
+      return {
+        title: titleMatch[1],
+        description: descriptionMatch[1],
+        image: imageMatch[1],
+      };
+    }
+
+    return null;
+  } catch (error) {
+    console.error('Error fetching OGP data:', error);
+    return null;
+  }
+}


### PR DESCRIPTION
Fixes #27

Replace URLs in specified formats with OGP block elements displaying the article title, first 50 characters of the content, and an image if available.

* **Add `fetchOGPData` utility function**: Create a new utility function `fetchOGPData` in `web/src/utils/fetchOGPData.ts` to fetch OGP data from URLs using `node-fetch`.
* **Create `OGPBlock` component**: Add a new component `OGPBlock` in `web/src/components/OGPBlock.astro` to display the OGP block elements with a stylish/cool card design.
* **Update `blog-post.astro` layout**: Modify `web/src/layouts/blog-post.astro` to import `OGPBlock` and update the Markdown rendering logic to replace URLs in the specified formats with `OGPBlock` components.
* **Update `note/index.astro` page**: Modify `web/src/pages/note/index.astro` to import `OGPBlock` and update the Markdown rendering logic to replace URLs in the specified formats with `OGPBlock` components.
* **Update `blog/index.astro` page**: Modify `web/src/pages/blog/index.astro` to import `OGPBlock` and update the Markdown rendering logic to replace URLs in the specified formats with `OGPBlock` components.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yaakaito/yaakaito/pull/39?shareId=291983eb-6192-4443-a7c6-9b19a6878e08).