### PR TITLE
Add OGP cards to blog posts

### DIFF
--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -1,6 +1,12 @@
 import { defineConfig } from 'astro/config';
+import remarkOgpCard from './scripts/remark-ogp-card.js';
 
 // https://astro.build/config
 export default defineConfig({
     site: 'https://yaakai.to',
+    markdown: {
+        remarkPlugins: [
+            remarkOgpCard
+        ]
+    }
 });

--- a/web/package.json
+++ b/web/package.json
@@ -7,11 +7,15 @@
     "start": "astro dev --host",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "remark-ogp-card": "node scripts/remark-ogp-card.js"
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.10",
     "astro": "5.0.5",
-    "sanitize-html": "^2.13.1"
+    "sanitize-html": "^2.13.1",
+    "remark": "^14.0.2",
+    "remark-html": "^15.0.0",
+    "node-fetch": "^3.2.0"
   }
 }

--- a/web/scripts/remark-ogp-card.js
+++ b/web/scripts/remark-ogp-card.js
@@ -1,0 +1,73 @@
+import { visit } from 'unist-util-visit';
+import { h } from 'hastscript';
+import { toHtml } from 'hast-util-to-html';
+
+async function fetchOgpData(url) {
+  const response = await fetch(url);
+  const html = await response.text();
+  const ogpData = { url };
+
+  let ogTitleMatch = html.match(/<meta property="og:title" content="([^"]+)"\/?>/);
+  if (!ogTitleMatch) {
+    ogTitleMatch = html.match(/<title>([^<]+)<\/title>/);
+  }
+  const ogDescriptionMatch = html.match(/<meta property="og:description" content="([^"]+)"\/?>/);
+  let ogImageMatch = html.match(/<meta property="og:image" content="([^"]+)"\/?>/) || html.match(/<meta name="og:image" content="([^"]+)"\/?>/);
+  if (ogImageMatch && ogImageMatch[1].startsWith('/')) {
+    const urlObj = new URL(url);
+    ogImageMatch[1] = `${urlObj.origin}${ogImageMatch[1]}`;
+  }
+
+  
+  if (ogTitleMatch) ogpData.title = ogTitleMatch[1];
+  if (ogDescriptionMatch) ogpData.description = ogDescriptionMatch[1];
+  if (ogImageMatch) ogpData.image = ogImageMatch[1];
+
+  return ogpData;
+}
+
+function createOgpCard(url, ogpData) {
+  return h('a', { href: url, class: 'ogp-card' }, [
+    ogpData.image ? h('img', { src: ogpData.image, alt: ogpData.title }) : null,
+    h('div', { class: 'ogp-content' }, [
+      h('h3', ogpData.title),
+      h('p', ogpData.description),
+    ]),
+  ]);
+}
+
+function remarkOgpCard() {
+  return async (tree) => {
+    const promises = [];
+
+    const processNode = (node, url) => {
+      const promise = fetchOgpData(url).then((ogpData) => {
+        const card = createOgpCard(url, ogpData);
+        node.type = 'html';
+        node.value = toHtml(card);
+      });
+      promises.push(promise);
+    };
+
+    visit(tree, 'list', (node) => {
+      // すべて link なら、すべてカードに置き換える
+      if (node.children.every((listItem) => listItem.children.length === 1 && listItem.children[0].type === 'paragraph' && listItem.children[0].children.length === 1 && listItem.children[0].children[0].type === 'link')) {
+        const urls = node.children.map((listItem) => {
+          const url = listItem.children[0].children[0].url;
+          return url;
+        });
+        const promise = Promise.all(urls.map((url) => fetchOgpData(url))).then((ogpDataList) => {
+          node.type = 'html';
+          node.value = toHtml(h('div', { class: 'ogp-card-list' }, ogpDataList.map((ogpData) => {
+            return createOgpCard(ogpData.url, ogpData);
+          })));
+        });
+        promises.push(promise);
+      }
+    });
+
+    await Promise.all(promises);
+  };
+}
+
+export default remarkOgpCard;

--- a/web/src/layouts/blog-post.astro
+++ b/web/src/layouts/blog-post.astro
@@ -66,6 +66,7 @@ const dateString = new Date(frontmatter.date).toLocaleDateString("en-US", {
             border-radius: 50%;
             vertical-align: middle;
         }
+
     </style>
     <style is:global>
         .markdown {
@@ -170,6 +171,77 @@ const dateString = new Date(frontmatter.date).toLocaleDateString("en-US", {
             font-size: 0.9em;
             color: var(--text-color-level-2);
         }
+        .ogp-card {
+            margin: 1em 0;
+  display: flex;
+  height: 96px;
+  width: 100%;
+  background-color: var(--bg-color-level-1);
+  border: 1px solid var(--bg-color-level-3);
+  border-radius: 8px;
+  overflow: hidden;
+  text-decoration: none;
+  transition: all 0.2s ease-in-out;
+}
+
+.ogp-card:hover {
+  transform: translateY(-1px);
+  background-color: var(--bg-color-level-2);
+  border-color: var(--bg-color-level-4);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.ogp-card img {
+  width: 200px;
+  height: 96px;
+  object-fit: cover;
+  order: 2;
+  flex-shrink: 0; /* 画像サイズを固定 */
+  background-color: var(--bg-color-level-0);
+}
+
+.ogp-content {
+  flex: 1;
+  min-width: 0; /* テキストの省略のために必要 */
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+}
+
+.ogp-content h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-color-level-0);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%; /* 親要素の幅を超えない */
+}
+
+.ogp-content p {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-color-level-2);
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  line-height: 1.4;
+  max-height: 2.8em; /* 2行分の高さを固定 */
+}
+
+@media (prefers-color-scheme: dark) {
+  .ogp-card:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  }
+  
+  .ogp-card img {
+    opacity: 0.9;
+  }
+}
     </style>
     <div class="container">
         <hgroup class="header">


### PR DESCRIPTION
Fixes #27

Add OGP card replacement for URLs in markdown during `astro build`.

* **Configuration Changes:**
  - Modify `web/astro.config.mjs` to include `remarkOgpCard` in `markdown.remarkPlugins`.
  - Update `web/package.json` to add dependencies for `remark`, `remark-html`, and `node-fetch`.

* **New Plugin:**
  - Add `web/scripts/remark-ogp-card.js` to fetch OGP information and replace URLs with OGP cards.

* **Styling:**
  - Update `web/src/layouts/blog-post.astro` to include styles for OGP cards, ensuring the card appearance is approximately 96px in height with an image positioned on the right side.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yaakaito/yaakaito/pull/40?shareId=a66bb3ca-0497-429b-a108-63d1a99ca264).