### PR TITLE
倍率選択に12xオプションを追加

### DIFF
--- a/related-articles-worker/public/index.html
+++ b/related-articles-worker/public/index.html
@@ -471,6 +471,7 @@
                                                         <option value="2">2x</option>
                                                         <option value="4">4x</option>
                                                         <option value="8" selected>8x</option>
+                                                        <option value="12">12x</option>
                                                         <option value="16">16x</option>
                                                     </select>
                                                     <button id="applyScaleButton" style="margin-left: 0.5rem;">倍率を適用</button>


### PR DESCRIPTION
## 概要
Issue #52 「倍率を 12x も選べるようにする」の修正を実装しました。

## 変更内容
- アイキャッチ画像エディタの最終出力セクションにある倍率選択のドロップダウンメニューに「12x」のオプションを追加
- ユーザーが1x, 2x, 4x, 8x, 12x, 16xの6つの倍率から選択できるようになりました

## スクリーンショット
（なし）

fixes #52