### PR TITLE
関連記事APIでブログ記事のタイトルが表示されない問題を修正

### DIFF
--- a/web/scripts/register-articles.ts
+++ b/web/scripts/register-articles.ts
@@ -44,9 +44,11 @@ function convertMarkdownToPlainText(markdown: string): string {
 }
 
 function extractMetadataFromMarkdown(content: string): ArticleMetadata {
-    const titleMatch = content.match(/title:\s*"([^"]+)"/);
+    // titleをダブルクォートありとなしの両方のパターンに対応
+    const titleMatch = content.match(/title:\s*"([^"]+)"|title:\s*([^\n]+)/);
     const emojiMatch = content.match(/emoji:\s*([^\n]+)/);
-    const title = titleMatch ? titleMatch[1] : '';
+    // titleMatch[1]はクォートあり、titleMatch[2]はクォートなしの場合にマッチ
+    const title = titleMatch ? (titleMatch[1] || titleMatch[2] || '').trim() : '';
     const emoji = emojiMatch ? emojiMatch[1].trim() : '';
 
     // フロントマターを除去（---で囲まれた部分を削除）


### PR DESCRIPTION
## Summary
- 記事登録スクリプトのタイトル抽出正規表現を修正
- クォートありとクォートなしの両形式に対応

## Test plan
- [ ] register-articles.tsスクリプトを実行し、blog記事とnote記事の両方でタイトルが正しく抽出されることを確認
- [ ] 関連記事APIからタイトルが正しく返されることを確認
- [ ] ブログページで関連記事のタイトルが表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)