### PR TITLE
関連記事のキャッシュパージ実装を改善

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -60,7 +60,57 @@ jobs:
         env:
           ARTICLES_API_KEY: ${{ secrets.ARTICLES_API_KEY }}
         run: |
-          curl -X POST https://articles.yaakai.to/purge_cache -H "X-API-Key: $ARTICLES_API_KEY"
+          # 登録された記事のIDを収集してキャッシュをパージ
+          cd web
+          ARTICLE_IDS=$(bun run -e "
+            import fs from 'fs/promises';
+            import path from 'path';
+            
+            async function findMarkdownFiles(dir) {
+              const files = [];
+              const entries = await fs.readdir(dir, { withFileTypes: true });
+              for (const entry of entries) {
+                const fullPath = path.join(dir, entry.name);
+                if (entry.isDirectory()) {
+                  files.push(...await findMarkdownFiles(fullPath));
+                } else if (entry.isFile() && entry.name.endsWith('.md')) {
+                  files.push(fullPath);
+                }
+              }
+              return files;
+            }
+            
+            async function main() {
+              const ids = [];
+              
+              // blog記事のID
+              const blogFiles = await findMarkdownFiles('src/pages/blog');
+              for (const file of blogFiles) {
+                const relativePath = path.relative('src/pages/blog', file);
+                const fileName = path.basename(relativePath, '.md');
+                ids.push('blog-' + fileName);
+              }
+              
+              // note記事のID
+              const noteFiles = await findMarkdownFiles('src/pages/note');
+              for (const file of noteFiles) {
+                if (!file.endsWith('index.md')) {
+                  const fileName = path.basename(file, '.md');
+                  ids.push('note-' + fileName);
+                }
+              }
+              
+              console.log(JSON.stringify(ids));
+            }
+            
+            main();
+          ")
+          
+          # キャッシュパージAPIを呼び出し
+          curl -X POST https://articles.yaakai.to/purge_cache \
+            -H "X-API-Key: $ARTICLES_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"articleIds\": $ARTICLE_IDS}"
 
   # Deployment job
   deploy:

--- a/related-articles-worker/src/index.ts
+++ b/related-articles-worker/src/index.ts
@@ -181,8 +181,22 @@ export default {
 			}
 
 			try {
-				// キャッシュを削除
-				await cache.delete(new Request(`${url.origin}/related_articles`));
+				const body = await request.json() as { articleIds?: string[] } | undefined;
+				const articleIds = body?.articleIds;
+
+				if (articleIds && articleIds.length > 0) {
+					// 指定された記事のキャッシュを削除
+					const deletePromises = articleIds.map(id => 
+						cache.delete(new Request(`${url.origin}/related_articles/${id}`))
+					);
+					await Promise.all(deletePromises);
+					console.log(`Purged cache for ${articleIds.length} articles`);
+				} else {
+					// 全記事のキャッシュを削除（VECTORIZEから全IDを取得）
+					// 注意: Vectorizeには全IDを取得するAPIがないため、
+					// 実際には個別のIDを管理する必要がある
+					console.log('Warning: Full cache purge requested but article IDs not provided');
+				}
 
 				return new Response(JSON.stringify({ success: true }), {
 					headers: { "Content-Type": "application/json" }


### PR DESCRIPTION
## Summary
- 関連記事APIのキャッシュパージを個別記事IDごとに削除できるように修正
- GitHub Actionsでデプロイ時に全記事IDを収集してパージするように改善

## 背景
- キャッシュは`/related_articles/${id}`形式で個別に保存されているが、パージは`/related_articles`全体を削除しようとしていた
- そのため、デプロイ後も古いキャッシュが残り、更新されたタイトルが表示されない問題があった

## Test plan
- [ ] related-articles-workerをデプロイ
- [ ] GitHub Actionsでデプロイを実行
- [ ] 関連記事のタイトルが正しく更新されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)