### PR TITLE
feat: add breadcrumb navigation and relocate publication date

### DIFF
--- a/web/src/components/Breadcrumb.astro
+++ b/web/src/components/Breadcrumb.astro
@@ -1,0 +1,50 @@
+---
+interface BreadcrumbSegment {
+    label: string;
+    href: string;
+}
+
+interface Props {
+    segments: BreadcrumbSegment[];
+}
+
+const { segments } = Astro.props;
+---
+
+<nav aria-label="breadcrumb" class="breadcrumb">
+    {segments.map((segment, index) => (
+        <>
+            <a href={segment.href} class="breadcrumb-link">
+                {segment.label}
+            </a>
+            {index < segments.length - 1 && (
+                <span class="breadcrumb-separator">/</span>
+            )}
+        </>
+    ))}
+    <span class="breadcrumb-separator">/</span>
+</nav>
+
+<style>
+    .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 0.9em;
+    }
+
+    .breadcrumb-link {
+        color: var(--text-color-level-1);
+        text-decoration: none;
+        transition: color 0.2s ease;
+    }
+
+    .breadcrumb-link:hover {
+        color: var(--primary-color-level-0);
+    }
+
+    .breadcrumb-separator {
+        color: var(--text-color-level-2);
+        user-select: none;
+    }
+</style>

--- a/web/src/layouts/blog-post.astro
+++ b/web/src/layouts/blog-post.astro
@@ -2,6 +2,7 @@
 import GlobalLayout from "../layouts/global-layout.astro";
 import ThemeSwitcher from "../components/ThemeSwitcher.astro";
 import CopyPageMenu from "../components/CopyPageMenu.astro";
+import Breadcrumb from "../components/Breadcrumb.astro";
 import { getGenericEyecatchColor } from "../utils/eyecatch";
 import icon from "../../../icon/icon-128.png";
 const { frontmatter, content } = Astro.props;
@@ -27,6 +28,12 @@ const ogImage = frontmatter.eyecatch
 
 // 完全なURL
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site || Astro.url.origin).href;
+
+// パンくずリストのデータを生成
+const breadcrumbSegments = [
+    { label: "yaakai.to", href: "/" },
+    { label: "blog", href: "/blog" }
+];
 ---
 <GlobalLayout
     title={frontmatter.title}
@@ -933,8 +940,11 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site || Astro.url.origin)
             }
 
             time {
+                display: block;
                 font-size: 0.9em;
                 color: var(--text-color-level-2);
+                margin-top: 12px;
+                text-align: left;
             }
 
             .title {
@@ -1246,10 +1256,11 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site || Astro.url.origin)
     <header class="article-header">
         <div class="article-header-inner">
             <div class="article-header-top">
-                <time datetime={frontmatter.date}>{dateString}</time>
+                <Breadcrumb segments={breadcrumbSegments} />
                 <ThemeSwitcher variant="toggle" />
             </div>
             <h1 class="title">{frontmatter.title}</h1>
+            <time datetime={frontmatter.date}>{dateString}</time>
         </div>
         {frontmatter.eyecatch ? (
             <div class="eyecatch-wrapper">


### PR DESCRIPTION
## Summary

This PR implements breadcrumb navigation for blog article pages and relocates the publication date from above the title to below it, as requested in #110.

### Changes

- Created a reusable `Breadcrumb` component (`web/src/components/Breadcrumb.astro`)
  - Displays navigation segments with "/" separators
  - Supports hover states with proper color transitions
  - Follows existing design patterns with CSS custom properties
  
- Updated `blog-post.astro` layout
  - Integrated breadcrumb navigation at top-left showing "yaakai.to / blog /"
  - Moved publication date from `article-header-top` to below the title
  - Maintained `ThemeSwitcher` position at top-right
  - Updated styles for relocated date element with proper spacing

### Implementation Details

- Breadcrumb component accepts a `segments` prop as an array of `{label: string, href: string}` objects
- Used semantic HTML with `<nav aria-label="breadcrumb">` for accessibility
- Applied flexbox layout for horizontal alignment
- Used CSS custom properties for theming (`--text-color-level-1`, `--text-color-level-2`, `--primary-color-level-0`)
- Date element now has `display: block`, `margin-top: 12px`, and left text alignment

### Visual Changes

Before:
```
[Date]                    [ThemeSwitcher]
Title
```

After:
```
[yaakai.to / blog /]      [ThemeSwitcher]
Title
[Date]
```

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- deploy-preview-start -->
## Preview URL

https://bdaba10f-yaakaito-web.yaakaito9838.workers.dev
<!-- deploy-preview-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * パンくずリストナビゲーション機能を追加しました。ユーザーが現在のページの階層構造を確認でき、より簡単にサイト内を移動できるようになりました。ブログの記事ページにパンくずリストが表示されるようになります。

* **改善**
  * ブログ記事ページのヘッダーレイアウトを改善し、日付の表示位置を調整しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->