### PR TITLE
feat: eyecatch画像のストレージをKVからR2に移行

### DIFF
--- a/related-articles-worker/wrangler.jsonc
+++ b/related-articles-worker/wrangler.jsonc
@@ -33,6 +33,13 @@
       "id": "dbb3eef7798f4ece9e170a9b09c0b077",
       "preview_id": "fb44463e67bb40c9b1ca95a5b542e6de"
     }
+  ],
+  "r2_buckets": [
+    {
+      "binding": "EYECATCH_R2",
+      "bucket_name": "eyecatch-images",
+      "preview_bucket_name": "eyecatch-images-preview"
+    }
   ]
   /**
    * Smart Placement


### PR DESCRIPTION
## 概要

eyecatch画像の保存先をKVからR2に移行しました。既存のKVに保存されている画像との後方互換性を維持するため、取得時にはR2を優先し、見つからない場合はKVからフォールバックする仕組みを実装しています。

## 変更内容

- **wrangler.jsonc**: R2バケット設定(`EYECATCH_R2`)を追加
- **Envインターフェース**: `EYECATCH_R2: R2Bucket`バインディングを追加
- **アップロード処理** (`/upload_eyecatch`):
  - Base64エンコードされた画像データをバイナリ(Uint8Array)に変換
  - R2に`{id}.png`として保存（Content-Type: image/png）
  - 記事メタデータはKVに保存（既存の動作を維持）
- **取得処理** (`/eyecatch`):
  - まずR2から`{id}.png`を取得
  - R2に存在しない場合、KVから`eyecatch:{id}`を取得（後方互換性）
  - Base64データのデコード処理を維持

## テスト計画

- [ ] R2バケット(`eyecatch-images`および`eyecatch-images-preview`)を作成
- [ ] 新規画像のアップロードが正常に動作することを確認
- [ ] 新規画像の取得が正常に動作することを確認
- [ ] 既存のKVに保存されている画像が引き続き取得できることを確認（フォールバック）
- [ ] エラーハンドリングが適切に機能することを確認

## 関連Issue

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- deploy-preview-start -->
## Preview URL

https://78c1b0d1-yaakaito-web.yaakaito9838.workers.dev
<!-- deploy-preview-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 画像ストレージの管理機構を最適化し、より堅牢で信頼性の高い検索プロセスを実装しました。
  * 既存システムとの互換性を維持しながら、バックアップ機構を強化して安定性を向上させました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->