### PR TITLE
feat: パンくずリストの実装と日付位置の変更

### DIFF
--- a/web/src/components/Breadcrumb.astro
+++ b/web/src/components/Breadcrumb.astro
@@ -1,0 +1,67 @@
+---
+interface Props {
+    pathname: string;
+}
+
+const { pathname } = Astro.props;
+
+// パスを分割してセグメントを抽出
+const segments = pathname.split('/').filter(Boolean);
+
+// パンくずアイテムを生成
+interface BreadcrumbItem {
+    label: string;
+    href: string;
+}
+
+const breadcrumbItems: BreadcrumbItem[] = [
+    { label: 'yaakai.to', href: '/' }
+];
+
+// セグメントからパンくずを構築
+for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i];
+
+    // blogまたはnoteのみを追加（年や記事スラッグは除外）
+    if (segment === 'blog') {
+        breadcrumbItems.push({ label: 'blog', href: '/blog' });
+    } else if (segment === 'note') {
+        breadcrumbItems.push({ label: 'note', href: '/note' });
+    }
+}
+---
+
+<nav class="breadcrumb">
+    {breadcrumbItems.map((item, index) => (
+        <>
+            <a href={item.href} class="breadcrumb-link">{item.label}</a>
+            <span class="breadcrumb-separator">/</span>
+        </>
+    ))}
+</nav>
+
+<style>
+    .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 0.5em;
+        font-size: 0.9em;
+        color: var(--text-color-level-2);
+        margin-bottom: 0.75em;
+    }
+
+    .breadcrumb-link {
+        color: var(--text-color-level-2);
+        text-decoration: none;
+        transition: color 0.2s ease;
+    }
+
+    .breadcrumb-link:hover {
+        color: var(--primary-color-level-0);
+    }
+
+    .breadcrumb-separator {
+        color: var(--text-color-level-2);
+        user-select: none;
+    }
+</style>

--- a/web/src/layouts/blog-post.astro
+++ b/web/src/layouts/blog-post.astro
@@ -2,6 +2,7 @@
 import GlobalLayout from "../layouts/global-layout.astro";
 import ThemeSwitcher from "../components/ThemeSwitcher.astro";
 import CopyPageMenu from "../components/CopyPageMenu.astro";
+import Breadcrumb from "../components/Breadcrumb.astro";
 import { getGenericEyecatchColor } from "../utils/eyecatch";
 import icon from "../../../icon/icon-128.png";
 const { frontmatter, content } = Astro.props;
@@ -962,7 +963,7 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site || Astro.url.origin)
 
             .article-header-top {
                 display: flex;
-                justify-content: space-between;
+                justify-content: flex-end;
                 align-items: center;
                 margin-bottom: 0.5em;
                 text-align: left;
@@ -1028,6 +1029,17 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site || Astro.url.origin)
                 letter-spacing: 0.02em;
                 color: var(--text-color-level-0);
                 text-align: left;
+            }
+
+            .article-date {
+                text-align: center;
+                margin-top: 0.75em;
+                margin-bottom: 1.5em;
+            }
+
+            .article-date time {
+                font-size: 0.9em;
+                color: var(--text-color-level-2);
             }
 
             /* Chrome系ブラウザでの文節境界改行 */
@@ -1246,6 +1258,11 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site || Astro.url.origin)
                     font-size: 2em;
                 }
 
+                .article-date {
+                    margin-top: 0.6em;
+                    margin-bottom: 1.2em;
+                }
+
                 .emoji {
                     font-size: 5em;
                 }
@@ -1262,6 +1279,11 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site || Astro.url.origin)
 
                 .title {
                     font-size: 1.6em;
+                }
+
+                .article-date {
+                    margin-top: 0.5em;
+                    margin-bottom: 1em;
                 }
 
                 .ai-badge {
@@ -1322,11 +1344,14 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site || Astro.url.origin)
     </style>
     <header class="article-header">
         <div class="article-header-inner">
+            <Breadcrumb pathname={Astro.url.pathname} />
             <div class="article-header-top">
-                <time datetime={frontmatter.date}>{dateString}</time>
                 <ThemeSwitcher variant="toggle" />
             </div>
             <h1 class="title">{frontmatter.title}</h1>
+            <div class="article-date">
+                <time datetime={frontmatter.date}>{dateString}</time>
+            </div>
         </div>
         {frontmatter.eyecatch ? (
             <div class="eyecatch-wrapper">


### PR DESCRIPTION
## 概要

各記事ページの左上部分にパンくずリストを追加し、日付の位置をタイトルの下に変更しました。

## 変更内容

### パンくずリストの実装
- 新規コンポーネント `Breadcrumb.astro` を作成
- テキストベースで "/" 区切りのパンくずリスト
- クリック可能なリンク（ホバー時にプライマリカラーに変化）
- 表示形式: `yaakai.to / blog /` または `yaakai.to / note /`
- 年やスラッグは含めず、トップレベルのカテゴリのみ表示

### 日付位置の変更
- 日付をヘッダートップからタイトルの下に移動
- ThemeSwitcher は右寄せで配置
- レスポンシブ対応（900px、480px ブレークポイント）

### スタイリング
- 既存のデザイントークンを使用 (`--text-color-level-2`, `--primary-color-level-0`)
- レスポンシブデザインに対応
- 中央揃えの日付表示

## 関連 Issue

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- deploy-preview-start -->
## Preview URL

https://e63c9f5a-yaakaito-web.yaakaito9838.workers.dev
<!-- deploy-preview-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * パンくずナビゲーションを追加し、ページ階層をわかりやすく表示

* **改善**
  * ブログ投稿ページの日付表示を改善し、より見やすいレイアウトに変更
  * モバイルデバイスでの表示最適化を実施

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->