### PR TITLE
refactor: ボタンをテキストリンクに変更

### DIFF
--- a/web/src/components/CopyPageMenu.astro
+++ b/web/src/components/CopyPageMenu.astro
@@ -7,13 +7,14 @@ const { url } = Astro.props;
 ---
 
 <div class="copy-page-container">
-  <a href="#" id="copy-page-link" class="copy-link">
+  <a href="#" id="copy-page-link" class="copy-link" role="button">
     Copy as Markdown
   </a>
   <a
     href="#"
     id="copy-dropdown-toggle"
     class="dropdown-toggle"
+    role="button"
     aria-label="More options"
     popovertarget="copy-dropdown-menu"
     popovertargetaction="toggle"
@@ -26,9 +27,9 @@ const { url } = Astro.props;
     data-url={url}
     popover="auto"
   >
-    <a href="#" class="dropdown-item" data-action="copy-page">Copy as Markdown</a>
-    <a href="#" class="dropdown-item" data-action="view-markdown">View as Markdown</a>
-    <a href="#" class="dropdown-item" data-action="copy-markdown-url">Copy Markdown URL</a>
+    <a href="#" class="dropdown-item" role="button" data-action="copy-page">Copy as Markdown</a>
+    <a href="#" class="dropdown-item" role="button" data-action="view-markdown">View as Markdown</a>
+    <a href="#" class="dropdown-item" role="button" data-action="copy-markdown-url">Copy Markdown URL</a>
   </div>
 </div>
 
@@ -177,8 +178,6 @@ const { url } = Astro.props;
       if (pathname.match(/^\/note\/[^/]+\/?$/)) {
         return pathname.replace(/\/$/, '') + '.md';
       }
-
-      console.log(pathname)
 
       return pathname;
     }


### PR DESCRIPTION
Copy as Markdown とドロップダウンメニューの項目をボタンからテキストリンクに変更。Chrome の Split 拡張機能などでより使いやすくなります。

## Key Changes

- `web/src/components/CopyPageMenu.astro` - ボタン要素をリンク要素に変更し、スタイルとイベントハンドラを更新

## Technical Details

- ボタン要素 (`<button>`) をリンク要素 (`<a href="#">`) に変更
- CSS スタイルをボタン風からリンク風に変更（`text-decoration: underline` on hover など）
- JavaScript のイベントハンドラに `e.preventDefault()` を追加してデフォルトのリンク動作を防止
- 要素 ID と CSS クラス名を変更（`copy-button` → `copy-link`, `dropdown-button` → `dropdown-toggle`）
- 成功時のフィードバック表示スタイルを調整（背景色変更から文字色と太さ変更へ）

## Breaking Changes

- None

## Dependency Changes

- None

## Related Documentation

- Fixes #97

<!-- deploy-preview-start -->
## Preview URL

https://660513a0-yaakaito-web.yaakaito9838.workers.dev
<!-- deploy-preview-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * コピーページメニューの操作をボタンからリンク形式へ置き換え、動作は維持しました（クリックでのコピーなど）。

* **Style**
  * リンク向けのスタイルを追加・調整（配列の間隔、中央揃え、ホバー/アクティブ表示、装飾の調整）。
  * フィードバック文言を更新：成功「Copied!」、失敗「Copy failed」、エラー「Error」。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->