### PR TITLE
コードブロックにコピーボタンを追加

### DIFF
--- a/web/src/layouts/blog-post.astro
+++ b/web/src/layouts/blog-post.astro
@@ -1485,6 +1485,7 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site || Astro.url.origin)
                 copyButton.className = 'code-copy-button';
                 copyButton.textContent = 'copy';
                 copyButton.setAttribute('aria-label', 'コードをクリップボードにコピー');
+                let resetTimeout: number | null = null;
                 copyButton.addEventListener('click', async function() {
                     try {
                         // コードの内容をコピー
@@ -1496,11 +1497,17 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site || Astro.url.origin)
                         copyButton.setAttribute('aria-label', 'コピー完了');
                         copyButton.classList.add('copied');
 
+                        // 既存のタイムアウトをクリア
+                        if (resetTimeout !== null) {
+                            clearTimeout(resetTimeout);
+                        }
+
                         // 2秒後に元に戻す
-                        setTimeout(() => {
+                        resetTimeout = setTimeout(() => {
                             copyButton.textContent = 'copy';
                             copyButton.setAttribute('aria-label', 'コードをクリップボードにコピー');
                             copyButton.classList.remove('copied');
+                            resetTimeout = null;
                         }, 2000);
                     } catch (err) {
                         console.error('コピーに失敗しました:', err);


### PR DESCRIPTION
記事のコードブロック内のコードをコピーするボタンを実装しました。

## Key Changes

- `web/src/layouts/blog-post.astro`: コピーボタンのスタイル定義とJavaScript実装を追加

## Technical Details

- コードブロックの右上にコピーボタンを配置
- ボタンのテキストは「copy」、クリック時にコードをクリップボードにコピー
- コピー成功時は「copied!」と表示し、2秒後に「copy」に戻る
- `navigator.clipboard.writeText` APIを使用してクリップボードにコピー
- ライト/ダークモード両方に対応したスタイリング
- 既存の展開ボタンと共存する実装

## Breaking Changes

- None

## Dependency Changes

- None

## Related Documentation

- Closes #93

<!-- deploy-preview-start -->
## Preview URL

https://8e7ba25a-yaakaito-web.yaakaito9838.workers.dev
<!-- deploy-preview-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Markdownのコードブロックにコピーボタンを追加。クリックでコードをクリップボードへコピーし、完了時に一時的な確認表示が出ます。

* **既知の問題**
  * 一部環境で同じコードブロックにボタンが重複して表示される場合があります（表示やコピーは動作しますが修正予定です）。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->