### PR TITLE
パンくずリストの実装

### DIFF
--- a/web/src/components/Breadcrumb.astro
+++ b/web/src/components/Breadcrumb.astro
@@ -1,0 +1,55 @@
+---
+interface Props {
+    pathname: string;
+}
+
+const { pathname } = Astro.props;
+
+// パス名から最初のセグメントのみを取得（現在のページは除く）
+const segments = pathname.split('/').filter(Boolean);
+const firstSegment = segments.length > 0 ? segments[0] : null;
+
+// サイト名とセクションのパンくずリストを構築
+const breadcrumbItems = [
+    { label: 'yaakai.to', href: '/' }
+];
+
+if (firstSegment) {
+    breadcrumbItems.push({
+        label: firstSegment,
+        href: `/${firstSegment}/`
+    });
+}
+---
+
+<nav class="breadcrumb">
+    {breadcrumbItems.map((item, index) => (
+        <>
+            <a href={item.href} class="breadcrumb-link">{item.label}</a>
+            <span class="breadcrumb-separator"> / </span>
+        </>
+    ))}
+</nav>
+
+<style>
+    .breadcrumb {
+        display: flex;
+        align-items: center;
+        font-size: 0.9em;
+    }
+
+    .breadcrumb-link {
+        color: var(--text-color-level-2);
+        text-decoration: none;
+        padding: 0 4px;
+        transition: all 0.2s ease-in-out;
+    }
+
+    .breadcrumb-link:hover {
+        color: var(--primary-color-level-0);
+    }
+
+    .breadcrumb-separator {
+        color: var(--text-color-level-2);
+    }
+</style>

--- a/web/src/layouts/blog-post.astro
+++ b/web/src/layouts/blog-post.astro
@@ -2,6 +2,7 @@
 import GlobalLayout from "../layouts/global-layout.astro";
 import ThemeSwitcher from "../components/ThemeSwitcher.astro";
 import CopyPageMenu from "../components/CopyPageMenu.astro";
+import Breadcrumb from "../components/Breadcrumb.astro";
 import { getGenericEyecatchColor } from "../utils/eyecatch";
 import icon from "../../../icon/icon-128.png";
 const { frontmatter, content } = Astro.props;
@@ -1014,6 +1015,13 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site || Astro.url.origin)
                 color: var(--text-color-level-2);
             }
 
+            .article-date {
+                display: block;
+                text-align: center;
+                margin-top: 0.8em;
+                margin-bottom: 1.2em;
+            }
+
             .title {
                 font-size: 2.4em;
                 font-weight: bold;
@@ -1323,10 +1331,11 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site || Astro.url.origin)
     <header class="article-header">
         <div class="article-header-inner">
             <div class="article-header-top">
-                <time datetime={frontmatter.date}>{dateString}</time>
+                <Breadcrumb pathname={Astro.url.pathname} />
                 <ThemeSwitcher variant="toggle" />
             </div>
             <h1 class="title">{frontmatter.title}</h1>
+            <time class="article-date" datetime={frontmatter.date}>{dateString}</time>
         </div>
         {frontmatter.eyecatch ? (
             <div class="eyecatch-wrapper">


### PR DESCRIPTION
各記事ページの左上部分にパンくずリストを追加し、日付表示をタイトル下に移動しました。

## Key Changes

- `web/src/components/Breadcrumb.astro` - パンくずリストコンポーネントを新規作成
- `web/src/layouts/blog-post.astro` - レイアウトにパンくずリストを統合し、日付位置を変更

## Technical Details

- パンくずリストは「yaakai.to / セクション名 /」形式で表示（現在のページは除外）
- パス名から最初のセグメント（blog/note）のみを抽出して表示
- サイト名とセクション名はクリック可能なリンクとして実装
- CSS変数（`--text-color-level-2`、`--primary-color-level-0`）を使用したテーマ対応
- ホバー時にプライマリカラーで強調表示
- 日付をタイトル下に移動し、中央揃えで配置
- レスポンシブデザインに対応

## Breaking Changes

- None

## Dependency Changes

- None

## Related Documentation

- Fixes #122

<!-- deploy-preview-start -->
## Preview URL

https://f0f75b74-yaakaito-web.yaakaito9838.workers.dev
<!-- deploy-preview-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* 新しいパンくずナビゲーション機能を追加しました。現在のページのパス情報に基づいて自動的に生成され、ユーザーが訪問しているページの階層を視覚的に確認できるようになります。
* ブログ投稿ページにパンくずナビゲーションを統合し、記事タイトル下部に表示されるようになりました。各パンくずのリンクをクリックすることで、関連ページへの移動も可能です。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->