### PR TITLE
注釈は Pop Over で Top Layer に出すようにする

### DIFF
--- a/web/src/layouts/blog-post.astro
+++ b/web/src/layouts/blog-post.astro
@@ -1470,6 +1470,9 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site || Astro.url.origin)
             // 注釈ポップオーバー要素を作成
             const footnotePopover = document.createElement('div');
             footnotePopover.className = 'footnote-popover';
+            footnotePopover.setAttribute('role', 'tooltip');
+            footnotePopover.setAttribute('id', 'footnote-popover');
+            footnotePopover.setAttribute('aria-hidden', 'true');
             document.body.appendChild(footnotePopover);
 
             // すべての注釈参照リンクにクリックイベントを追加
@@ -1492,6 +1495,9 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site || Astro.url.origin)
                         // 同じ注釈を再クリックした場合は閉じる
                         if (currentFootnoteRef === refLink && footnotePopover.style.display === 'block') {
                             footnotePopover.style.display = 'none';
+                            footnotePopover.setAttribute('aria-hidden', 'true');
+                            refLink.setAttribute('aria-expanded', 'false');
+                            refLink.removeAttribute('aria-describedby');
                             currentFootnoteRef = null;
                             return;
                         }
@@ -1521,13 +1527,22 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site || Astro.url.origin)
 
                             // CSS Anchor Positioning非対応時は座標を計算して設定
                             if (!supportsAnchorPositioning) {
+                                // 高さを取得する前に表示状態にする
+                                footnotePopover.style.display = 'block';
+
                                 const rect = refLink.getBoundingClientRect();
                                 footnotePopover.style.left = `${rect.left + rect.width / 2}px`;
                                 footnotePopover.style.top = `${rect.top + window.scrollY - footnotePopover.offsetHeight - 8}px`;
+                            } else {
+                                // CSS Anchor Positioning対応時のみ表示を設定
+                                footnotePopover.style.display = 'block';
                             }
 
-                            // ポップオーバーを表示
-                            footnotePopover.style.display = 'block';
+                            // ARIA属性を設定してアクセシビリティを向上
+                            footnotePopover.setAttribute('aria-hidden', 'false');
+                            refLink.setAttribute('aria-expanded', 'true');
+                            refLink.setAttribute('aria-describedby', 'footnote-popover');
+
                             currentFootnoteRef = refLink;
                         }
                     });
@@ -1539,6 +1554,11 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site || Astro.url.origin)
                     if (!footnotePopover.contains(target) &&
                         !Array.from(footnoteRefs).some(ref => ref.contains(target))) {
                         footnotePopover.style.display = 'none';
+                        footnotePopover.setAttribute('aria-hidden', 'true');
+                        if (currentFootnoteRef) {
+                            currentFootnoteRef.setAttribute('aria-expanded', 'false');
+                            currentFootnoteRef.removeAttribute('aria-describedby');
+                        }
                         currentFootnoteRef = null;
                     }
                 });


### PR DESCRIPTION
注釈リンクをクリックするとスクロールせずにその場でポップオーバーで注釈内容を表示できるようにしました。

## Key Changes

- `web/src/layouts/blog-post.astro`: CSS Anchor Positioning を使用した注釈ポップオーバーの実装

## Technical Details

- CSS Anchor Positioning API を使用してアンカー要素（注釈リンク）に対してポップオーバーを表示
- JavaScript で注釈リンククリック時のイベント処理を実装
- 元の注釈セクション（`.footnotes`）は `display: none` で非表示に
- ポップオーバー外クリックで自動的に閉じる
- 同じ注釈を再クリックで表示/非表示を切り替え

## Breaking Changes

- None

## Dependency Changes

- None

## Related Documentation

- Issue #55
- 既存の AI バッジポップオーバー実装（`blog-post.astro:1109-1150`）を参考にした設計

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ブログ投稿の脚注にインタラクティブなポップオーバーを追加。脚注リンクをクリックでポップオーバー表示／非表示を切替。
  * ポップオーバーはクリック外で自動閉鎖、再クリックでトグル動作。
  * アンカー名による位置指定対応と、未対応ブラウザ向けの絶対座標フォールバックを提供。
  * ポップオーバー内の脚注表示を読みやすくするスタイル調整（タイポグラフィ、余白、行間）。
  * 既存のインタラクティブ機能との表示連携を維持。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- deploy-preview-start -->
## Preview URL

https://05b34cb8-yaakaito-web.yaakaito9838.workers.dev
<!-- deploy-preview-end -->