### PR TITLE
feat: 特集エリアのアイキャッチ表示を固定高さに変更

### DIFF
--- a/web/src/components/FeatureCard.astro
+++ b/web/src/components/FeatureCard.astro
@@ -152,18 +152,21 @@ const genericEyecatchColor = getGenericEyecatchColor(url);
   .feature-image-container-sub {
     flex: 0 0 35%;
     margin-right: 12px;
+    height: 120px;
+    overflow: hidden;
   }
 
   .feature-eyecatch-sub {
     width: 100%;
-    aspect-ratio: 16 / 9;
+    height: 100%;
     object-fit: cover;
+    object-position: center;
     border-radius: 6px;
   }
 
   .feature-emoji-container-sub {
     width: 100%;
-    aspect-ratio: 16 / 9;
+    height: 100%;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -319,6 +322,7 @@ const genericEyecatchColor = getGenericEyecatchColor(url);
     .feature-image-container-sub {
       flex: 0 0 35%;
       margin-right: 12px;
+      height: 100px;
     }
   }
 </style>


### PR DESCRIPTION
.feature-image-container-sub の画像・絵文字背景の表示方法を、縦幅を固定して横幅を切り抜く形式に変更しました。

## Key Changes

- `web/src/components/FeatureCard.astro` - サブ特集カードのアイキャッチCSSを固定高さに変更

## Technical Details

- `.feature-image-container-sub` に固定高さ (デスクトップ: 120px, モバイル: 100px) と `overflow: hidden` を追加
- `.feature-eyecatch-sub` から `aspect-ratio` を削除し、`height: 100%` と `object-position: center` を設定
- `.feature-emoji-container-sub` も同様に `aspect-ratio` を削除し、`height: 100%` を設定
- 画像は `object-fit: cover` と `object-position: center` により中央配置

## Breaking Changes

- None

## Dependency Changes

- None

## Related Documentation

- Fixes #135

<!-- deploy-preview-start -->
## Preview URL

https://5e020270-yaakaito-web.yaakaito9838.workers.dev
<!-- deploy-preview-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Style**
  * フィーチャーカードの画像表示を改善しました。画像コンテナの高さを固定し、モバイル環境での表示がより統一されるようになりました。画像のポジショニングを調整し、より適切なトリミング動作を実現しています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->