### PR TITLE
記事とセクションタイトルの装飾を削除

### DIFF
--- a/web/src/components/BlogCard.astro
+++ b/web/src/components/BlogCard.astro
@@ -23,7 +23,6 @@ const formattedDate = new Date(date).toLocaleDateString('ja-JP', {
 
 <a href={url} class="blog-card-link">
   <div class="blog-card">
-    <div class="blog-indicator"></div>
     <div class="blog-content">
       {eyecatch ? (
         <div class="blog-eyecatch-container">
@@ -76,17 +75,8 @@ const formattedDate = new Date(date).toLocaleDateString('ja-JP', {
     box-shadow: light-dark(0 4px 8px rgba(0, 0, 0, 0.1), 0 4px 8px rgba(0, 0, 0, 0.3));
   }
 
-  .blog-indicator {
-    position: absolute;
-    top: 0;
-    left: 0;
-    height: 100%;
-    width: 4px;
-    background-color: var(--blog-color);
-  }
-
   .blog-content {
-    padding: 16px 16px 16px 24px;
+    padding: 16px;
     flex-grow: 1;
     display: flex;
     flex-direction: column;

--- a/web/src/components/CategorySection.astro
+++ b/web/src/components/CategorySection.astro
@@ -70,19 +70,6 @@ const { title, type, posts, viewAllLink } = Astro.props;
     font-weight: bold;
     color: var(--text-color-level-0);
     margin: 0;
-    position: relative;
-    padding-left: 16px;
-  }
-
-  .category-title::before {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    width: 6px;
-    background-color: var(--primary-color-level-0);
-    border-radius: 3px;
   }
 
   .view-all-link {

--- a/web/src/components/FeatureCard.astro
+++ b/web/src/components/FeatureCard.astro
@@ -47,8 +47,6 @@ const genericEyecatchColor = getGenericEyecatchColor(url);
 
 <a href={url} class="feature-card-link">
   <div class={`feature-card ${isMain ? 'main-feature' : 'sub-feature'}`}>
-    <div class="feature-indicator"></div>
-
     {isMain ? (
       <div class="feature-content">
         <div class="feature-image-container-main">
@@ -130,16 +128,6 @@ const genericEyecatchColor = getGenericEyecatchColor(url);
     box-shadow: light-dark(0 8px 16px rgba(0, 0, 0, 0.12), 0 8px 16px rgba(0, 0, 0, 0.4));
   }
 
-  .feature-indicator {
-    position: absolute;
-    top: 0;
-    left: 0;
-    height: 100%;
-    width: 6px;
-    background-color: var(--blog-color);
-    z-index: 1;
-  }
-
   /* サブカード（右側）用の横型レイアウト */
   .feature-sub-layout {
     display: flex;
@@ -184,7 +172,7 @@ const genericEyecatchColor = getGenericEyecatchColor(url);
   }
 
   .feature-content {
-    padding: 20px 20px 20px 26px;
+    padding: 20px;
     flex-grow: 1;
     display: flex;
     flex-direction: column;
@@ -269,12 +257,8 @@ const genericEyecatchColor = getGenericEyecatchColor(url);
     box-shadow: light-dark(0 2px 4px rgba(0, 0, 0, 0.05), 0 2px 4px rgba(0, 0, 0, 0.2));
   }
 
-  .sub-feature .feature-indicator {
-    width: 4px;
-  }
-
   .sub-feature .feature-content {
-    padding: 16px 16px 16px 20px;
+    padding: 16px;
   }
 
   .sub-feature .feature-title {
@@ -290,7 +274,7 @@ const genericEyecatchColor = getGenericEyecatchColor(url);
     }
 
     .feature-content {
-      padding: 16px 16px 16px 22px;
+      padding: 16px;
     }
 
     /* モバイル表示の調整 */

--- a/web/src/components/NoteCard.astro
+++ b/web/src/components/NoteCard.astro
@@ -22,7 +22,6 @@ const genericEyecatchColor = getGenericEyecatchColor(url);
 
 <a href={url} class="note-card-link">
   <div class="note-card">
-    <div class="note-indicator"></div>
     <div class="note-content">
       {eyecatch ? (
         <div class="note-eyecatch-container">
@@ -74,18 +73,9 @@ const genericEyecatchColor = getGenericEyecatchColor(url);
     transform: translateY(-2px);
     box-shadow: light-dark(0 4px 8px rgba(0, 0, 0, 0.1), 0 4px 8px rgba(0, 0, 0, 0.3));
   }
-  .note-indicator {
-    position: absolute;
-    top: 0;
-    left: 0;
-    height: 100%;
-    width: 4px;
-    background-color: var(--note-color);
-  }
-
 
   .note-content {
-    padding: 16px 16px 16px 24px;
+    padding: 16px;
     flex-grow: 1;
     display: flex;
     flex-direction: column;
@@ -156,7 +146,7 @@ const genericEyecatchColor = getGenericEyecatchColor(url);
 
   @media (max-width: 768px) {
     .note-content {
-      padding: 12px 12px 12px 20px;
+      padding: 12px;
     }
 
     .note-emoji {

--- a/web/src/pages/blog/index.astro
+++ b/web/src/pages/blog/index.astro
@@ -64,19 +64,6 @@ const blogs = loadPosts(blogPosts);
     font-weight: bold;
     margin: 0 0 8px 0;
     color: var(--text-color-level-0);
-    position: relative;
-    padding-left: 16px;
-  }
-
-  .blog-title::before {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    width: 6px;
-    background-color: var(--blog-color);
-    border-radius: 3px;
   }
 
   .blog-description {

--- a/web/src/pages/note/index.astro
+++ b/web/src/pages/note/index.astro
@@ -83,19 +83,6 @@ const ogImage = notes.length > 0 && notes[0].frontmatter.eyecatch
     font-weight: bold;
     margin: 0 0 8px 0;
     color: var(--text-color-level-0);
-    position: relative;
-    padding-left: 16px;
-  }
-
-  .note-title::before {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    width: 6px;
-    background-color: var(--note-color);
-    border-radius: 3px;
   }
 
   .note-description {


### PR DESCRIPTION
記事カードの左側の色帯（`.blog-indicator`、`.feature-indicator`、`.note-indicator`）とセクションタイトルの装飾（`::before` 疑似要素）を削除しました。

## Key Changes

- `web/src/components/BlogCard.astro` - blog-indicator の削除とパディングの調整
- `web/src/components/FeatureCard.astro` - feature-indicator の削除とパディングの調整
- `web/src/components/NoteCard.astro` - note-indicator の削除とパディングの調整
- `web/src/components/CategorySection.astro` - セクションタイトルの装飾を削除
- `web/src/pages/blog/index.astro` - ページタイトルの装飾を削除
- `web/src/pages/note/index.astro` - ページタイトルの装飾を削除

## Technical Details

- 各カードコンポーネントから indicator div 要素と対応する CSS を削除
- カード内のコンテンツのパディングを均等に調整（左側の余白を削除）
- セクションタイトルとページタイトルから `::before` 疑似要素と `padding-left` を削除
- レスポンシブ対応のパディング調整も含む

## Breaking Changes

- None

## Dependency Changes

- None

## Related Documentation

- Fixes #137

<!-- deploy-preview-start -->
## Preview URL

https://5f85806a-yaakaito-web.yaakaito9838.workers.dev
<!-- deploy-preview-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * ブログ、カテゴリー、機能、ノート各コンポーネントの装飾的な左側インジケーターを削除し、UIを簡素化しました。
  * ページ全体のパディングを統一して、よりシンプルで一貫性のあるレイアウトを実現しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->