### PR TITLE
記事カードから装飾用インジケーターを削除

### DIFF
--- a/web/src/components/BlogCard.astro
+++ b/web/src/components/BlogCard.astro
@@ -23,7 +23,6 @@ const formattedDate = new Date(date).toLocaleDateString('ja-JP', {
 
 <a href={url} class="blog-card-link">
   <div class="blog-card">
-    <div class="blog-indicator"></div>
     <div class="blog-content">
       {eyecatch ? (
         <div class="blog-eyecatch-container">
@@ -76,17 +75,8 @@ const formattedDate = new Date(date).toLocaleDateString('ja-JP', {
     box-shadow: light-dark(0 4px 8px rgba(0, 0, 0, 0.1), 0 4px 8px rgba(0, 0, 0, 0.3));
   }
 
-  .blog-indicator {
-    position: absolute;
-    top: 0;
-    left: 0;
-    height: 100%;
-    width: 4px;
-    background-color: var(--blog-color);
-  }
-
   .blog-content {
-    padding: 16px 16px 16px 24px;
+    padding: 16px;
     flex-grow: 1;
     display: flex;
     flex-direction: column;

--- a/web/src/components/FeatureCard.astro
+++ b/web/src/components/FeatureCard.astro
@@ -47,8 +47,6 @@ const genericEyecatchColor = getGenericEyecatchColor(url);
 
 <a href={url} class="feature-card-link">
   <div class={`feature-card ${isMain ? 'main-feature' : 'sub-feature'}`}>
-    <div class="feature-indicator"></div>
-
     {isMain ? (
       <div class="feature-content">
         <div class="feature-image-container-main">
@@ -130,16 +128,6 @@ const genericEyecatchColor = getGenericEyecatchColor(url);
     box-shadow: light-dark(0 8px 16px rgba(0, 0, 0, 0.12), 0 8px 16px rgba(0, 0, 0, 0.4));
   }
 
-  .feature-indicator {
-    position: absolute;
-    top: 0;
-    left: 0;
-    height: 100%;
-    width: 6px;
-    background-color: var(--blog-color);
-    z-index: 1;
-  }
-
   /* サブカード（右側）用の横型レイアウト */
   .feature-sub-layout {
     display: flex;
@@ -184,7 +172,7 @@ const genericEyecatchColor = getGenericEyecatchColor(url);
   }
 
   .feature-content {
-    padding: 20px 20px 20px 26px;
+    padding: 20px;
     flex-grow: 1;
     display: flex;
     flex-direction: column;
@@ -269,12 +257,8 @@ const genericEyecatchColor = getGenericEyecatchColor(url);
     box-shadow: light-dark(0 2px 4px rgba(0, 0, 0, 0.05), 0 2px 4px rgba(0, 0, 0, 0.2));
   }
 
-  .sub-feature .feature-indicator {
-    width: 4px;
-  }
-
   .sub-feature .feature-content {
-    padding: 16px 16px 16px 20px;
+    padding: 16px;
   }
 
   .sub-feature .feature-title {
@@ -290,7 +274,7 @@ const genericEyecatchColor = getGenericEyecatchColor(url);
     }
 
     .feature-content {
-      padding: 16px 16px 16px 22px;
+      padding: 16px;
     }
 
     /* モバイル表示の調整 */

--- a/web/src/components/NoteCard.astro
+++ b/web/src/components/NoteCard.astro
@@ -22,7 +22,6 @@ const genericEyecatchColor = getGenericEyecatchColor(url);
 
 <a href={url} class="note-card-link">
   <div class="note-card">
-    <div class="note-indicator"></div>
     <div class="note-content">
       {eyecatch ? (
         <div class="note-eyecatch-container">
@@ -74,18 +73,9 @@ const genericEyecatchColor = getGenericEyecatchColor(url);
     transform: translateY(-2px);
     box-shadow: light-dark(0 4px 8px rgba(0, 0, 0, 0.1), 0 4px 8px rgba(0, 0, 0, 0.3));
   }
-  .note-indicator {
-    position: absolute;
-    top: 0;
-    left: 0;
-    height: 100%;
-    width: 4px;
-    background-color: var(--note-color);
-  }
-
 
   .note-content {
-    padding: 16px 16px 16px 24px;
+    padding: 16px;
     flex-grow: 1;
     display: flex;
     flex-direction: column;
@@ -156,7 +146,7 @@ const genericEyecatchColor = getGenericEyecatchColor(url);
 
   @media (max-width: 768px) {
     .note-content {
-      padding: 12px 12px 12px 20px;
+      padding: 12px;
     }
 
     .note-emoji {


### PR DESCRIPTION
記事一覧やトップページに表示される記事カードから、赤や灰色の縦線インジケーターを削除しました。

## Key Changes

- `web/src/components/BlogCard.astro` - `.blog-indicator` 要素とCSSスタイルを削除、paddingを調整
- `web/src/components/NoteCard.astro` - `.note-indicator` 要素とCSSスタイルを削除、paddingを調整
- `web/src/components/FeatureCard.astro` - `.feature-indicator` 要素とCSSスタイルを削除、paddingを調整

## Technical Details

- 各カードコンポーネントから、左端に配置されていた絶対配置の縦線インジケーター（幅4-6px）を削除
- インジケーター分のスペースを確保していた左側の余分なpadding（20-26px）を通常のpadding（16-20px）に調整
- モバイル表示用のpadding調整も同様に対応

## Breaking Changes

- None

## Dependency Changes

- None

## Related Documentation

- Closes #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * カードコンポーネント（ブログ、機能、メモ）から左側の視覚的インジケータ要素を削除しました。
  * カードのパディング（内部間隔）を調整し、より統一されたレイアウトを実現しました。
  * モバイルデバイスのレスポンシブスペーシングも更新されています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- deploy-preview-start -->
## Preview URL

https://3ce93a1f-yaakaito-web.yaakaito9838.workers.dev
<!-- deploy-preview-end -->