### PR TITLE
feat: ブログ記事の画像にライトボックス機能を追加

### DIFF
--- a/web/src/layouts/blog-post.astro
+++ b/web/src/layouts/blog-post.astro
@@ -1592,7 +1592,12 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site || Astro.url.origin)
 
                 markdownImages.forEach((img) => {
                     const imgElement = img as HTMLImageElement;
-                    imgElement.addEventListener('click', () => {
+                    imgElement.addEventListener('click', (e) => {
+                        const link = imgElement.closest('a');
+                        if (link) {
+                            e.preventDefault();
+                            e.stopPropagation();
+                        }
                         lightboxImage.src = imgElement.src;
                         lightboxImage.alt = imgElement.alt || '';
                         lightbox.showModal();


### PR DESCRIPTION
## 概要

画像拡大したいなと思うことが何度かあったので良ければどうかなと 🙏 

- 画像クリックでモーダル拡大表示
- dialog要素を使用したアクセシブルな実装
- 背景クリック・閉じるボタン・画像クリックで閉じる

## 画面収録

https://github.com/user-attachments/assets/586c464a-68ab-4dd6-8540-5126d9481a5d



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ブログ記事のマークダウン画像に対するクライアント側ライトボックスを追加しました。画像をクリックするとオーバーレイで拡大表示され、背景・画像・クローズボタンで閉じられます。スタイルや表示挙動は追加で提供され、既存の関連記事読み込みやコード折りたたみ等の機能はそのまま維持されます。初期化は該当要素がある場合にのみ実行されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->