### PR TITLE
Remove subtle box shadow from profile card styling

### DIFF
--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -116,7 +116,6 @@ const noteSectionPosts = allNotes.slice(0, 4);
     background-color: var(--bg-color-level-1);
     border-radius: 12px;
     padding: 24px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
   }
 
   .profile-header {


### PR DESCRIPTION
## Summary
Removed the subtle box shadow from the profile card component to simplify the visual design and reduce visual complexity.

## Changes
- Removed `box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);` from the profile card styling

## Details
The box shadow was providing minimal visual depth with very low opacity (5%). Removing it creates a cleaner, flatter design aesthetic while maintaining the card's visual separation through the existing border-radius and background color.

https://claude.ai/code/session_01Y7UMAXkZZLBZ5DVkuGwjdn

<!-- deploy-preview-start -->
## Preview URL

https://637d1d54-yaakaito-web.yaakaito9838.workers.dev
<!-- deploy-preview-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * プロフィールカードの視覚的なデザインを調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->