### PR TITLE
fix(web): llms.txt を UTF-8 で配信して文字化けを防ぐ

### DIFF
--- a/web/public/_headers
+++ b/web/public/_headers
@@ -1,0 +1,5 @@
+/llms.txt
+  Content-Type: text/plain; charset=utf-8
+
+/llms-full.txt
+  Content-Type: text/plain; charset=utf-8


### PR DESCRIPTION
## 概要

https://yaakai.to/llms.txt が文字化けしていた問題を修正します。

## 原因

`src/pages/llms.txt.ts` / `llms-full.txt.ts` は `Content-Type: text/plain`（charset 未指定）で `Response` を返していますが、Astro の静的ビルドでプリレンダリングされた後、Cloudflare Workers の静的アセット配信ではエンドポイントで設定した `Content-Type` が保持されません。その結果 charset が明示されず、UTF-8 の日本語が文字化けします。

## 対応

`web/public/_headers` を追加し、対象ファイルに `Content-Type: text/plain; charset=utf-8` を明示します。`public/` はビルド時に `dist/` へコピーされ、wrangler のアセットディレクトリ（`./dist`）に含まれるため、Cloudflare Workers 静的アセットの `_headers` として反映されます。

```
/llms.txt
  Content-Type: text/plain; charset=utf-8

/llms-full.txt
  Content-Type: text/plain; charset=utf-8
```

## 確認

- `bun run build` を実行し、`dist/_headers` が期待どおり出力されることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtTHnRjEYMkMrS9b9dWvkJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtTHnRjEYMkMrS9b9dWvkJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * `/llms.txt` および `/llms-full.txt` が、UTF-8のプレーンテキストとして正しく配信されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- deploy-preview-start -->
## Preview URL

https://85aad521-yaakaito-web.yaakaito9838.workers.dev
<!-- deploy-preview-end -->