### PR TITLE
fix(web): 各ページの .md を UTF-8 で配信する

### DIFF
--- a/web/public/_headers
+++ b/web/public/_headers
@@ -3,3 +3,9 @@
 
 /llms-full.txt
   Content-Type: text/plain; charset=utf-8
+
+/blog/*.md
+  Content-Type: text/plain; charset=utf-8
+
+/note/*.md
+  Content-Type: text/plain; charset=utf-8


### PR DESCRIPTION
## 概要

llms.txt / llms-full.txt と同様に、各ページの `.md` エンドポイント（例: https://yaakai.to/blog/2026/dev-with-adr.md ）も charset が指定されず文字化けしていたため、`_headers` で UTF-8 を明示する。

## 背景

`src/pages/blog/[year]/[slug].md.astro` と `src/pages/note/[slug].md.astro` は `Content-Type: text/plain; charset=utf-8` を返しているが、Cloudflare Workers の静的アセット配信ではこの Content-Type が保持されず charset 未指定となる。これは #158 で llms.txt に対して対応したのと同じ問題。

## 変更内容

`web/public/_headers` に以下のルールを追加:

```
/blog/*.md
  Content-Type: text/plain; charset=utf-8

/note/*.md
  Content-Type: text/plain; charset=utf-8
```

Cloudflare の `_headers` はリクエストパスに対してマッチし、`*` は `/` を含めた任意の文字列にマッチするため、`/blog/2026/dev-with-adr.md` のような年ディレクトリを含むパスもカバーされる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KzJRURRV6gZCRgET1Rh3VZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KzJRURRV6gZCRgET1Rh3VZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ブログおよびノートのMarkdownファイルが、正しいプレーンテキスト形式で配信されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->